### PR TITLE
Fix potential null cursor exception

### DIFF
--- a/app/src/main/java/org/mozilla/scryer/filemonitor/MediaProviderDelegate.kt
+++ b/app/src/main/java/org/mozilla/scryer/filemonitor/MediaProviderDelegate.kt
@@ -22,15 +22,15 @@ class MediaProviderDelegate(private val context: Context, private val handler: H
                     return
                 }
 
-                val cursor = context.contentResolver.query(uri,
+                context.contentResolver.query(uri,
                         arrayOf(MediaStore.Images.Media.DISPLAY_NAME,
                                 MediaStore.Images.Media.DATA,
                                 MediaStore.Images.Media.DATE_ADDED),
                         null,
                         null,
-                        MediaStore.Images.Media.DATE_ADDED + " DESC")
-
-                cursor.use {
+                        MediaStore.Images.Media.DATE_ADDED + " DESC"
+                ).use {
+                    val cursor = it ?: return@use
                     if (cursor.moveToFirst()) {
                         val path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.Media.DATA))
                         val dateAdded = cursor!!.getLong(cursor.getColumnIndex(MediaStore.Images.Media.DATE_ADDED))
@@ -42,6 +42,7 @@ class MediaProviderDelegate(private val context: Context, private val handler: H
                         }
                     }
                 }
+
                 super.onChange(selfChange, uri)
             }
         }

--- a/app/src/main/java/org/mozilla/scryer/filemonitor/ScreenshotFetcher.kt
+++ b/app/src/main/java/org/mozilla/scryer/filemonitor/ScreenshotFetcher.kt
@@ -1,6 +1,7 @@
 package org.mozilla.scryer.filemonitor
 
 import android.content.Context
+import android.database.Cursor
 import android.provider.MediaStore
 import org.mozilla.scryer.persistence.CollectionModel
 import org.mozilla.scryer.persistence.ScreenshotModel
@@ -24,8 +25,13 @@ class ScreenshotFetcher {
         val selection = "${MediaStore.Images.ImageColumns.BUCKET_ID} IS NOT NULL) GROUP BY (${MediaStore.Images.ImageColumns.BUCKET_ID}"
         val results = mutableListOf<String>()
 
-        val cursor = context.contentResolver.query(uri, columns, selection, null, null)
-        cursor.use {
+        context.contentResolver.query(uri,
+                columns,
+                selection,
+                null,
+                null
+        ).use {
+            val cursor = it ?: return@use
             while (cursor.moveToNext()) {
                 val path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DATA)).trim()
                 if (path.contains("screenshot", true)) {


### PR DESCRIPTION
The nullable annotation used by ContentResolver#query() comes from inner android.annotation.Nullable, thus Kotlin was unable to infer that the return type should be Cursor? instead of Cursor!