### PR TITLE
Fix inconsistent column names used when querying db and retrieving column index.

### DIFF
--- a/app/src/main/java/org/mozilla/scryer/filemonitor/ScreenshotFetcher.kt
+++ b/app/src/main/java/org/mozilla/scryer/filemonitor/ScreenshotFetcher.kt
@@ -33,7 +33,11 @@ class ScreenshotFetcher {
         ).use {
             val cursor = it ?: return@use
             while (cursor.moveToNext()) {
-                val path = cursor.getString(cursor.getColumnIndex(MediaStore.Images.ImageColumns.DATA)).trim()
+                val index = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+                if (index < 0) {
+                    continue
+                }
+                val path = cursor.getString(index).trim()
                 if (path.contains("screenshot", true)) {
                     val folder = File(path).parent?.trimEnd(File.separatorChar) ?: continue
                     results.add(folder)


### PR DESCRIPTION
1. Original implementation uses "MediaStore.Images.Media.DATA" as the column name, but use "MediaStore.Images.ImageColumns.DATA" when asking for column index.
2. Check the returned value of getColumnIndex() and skip if it's negative
