### PR TITLE
Only show "Added to Unsorted" toast message when sorting screenshots that hadn't been categorized before

### DIFF
--- a/app/src/main/java/org/mozilla/scryer/sortingpanel/SortingPanelActivity.kt
+++ b/app/src/main/java/org/mozilla/scryer/sortingpanel/SortingPanelActivity.kt
@@ -376,7 +376,9 @@ class SortingPanelActivity : AppCompatActivity() {
         }
 
         sortingPanel.setActionCallback {
-            showAddedToast(unsortedCollection, unsortedScreenshots.isNotEmpty())
+            if (isSortingUncategorized) {
+                showAddedToast(unsortedCollection, unsortedScreenshots.isNotEmpty())
+            }
             onNewModelAvailable()
             panelModel.onNextScreenshot()
 


### PR DESCRIPTION
Fix #413 