### PR TITLE
Re-implement ContentScanner.getProgress()

### DIFF
--- a/app/src/main/java/org/mozilla/scryer/scan/FirebaseVisionTextHelper.kt
+++ b/app/src/main/java/org/mozilla/scryer/scan/FirebaseVisionTextHelper.kt
@@ -54,7 +54,7 @@ class FirebaseVisionTextHelper {
         suspend fun scanAndSave(updateListener: ((index: Int, total: Int) -> Unit)? = null) {
             scan { model, index, total ->
                 writeContentTextToDb(model, extractText((model)))
-                updateListener?.invoke(index, total)
+                updateListener?.invoke(index + 1, total)
             }
         }
 

--- a/app/src/main/java/org/mozilla/scryer/scan/ForegroundAndBackgroundCharging.kt
+++ b/app/src/main/java/org/mozilla/scryer/scan/ForegroundAndBackgroundCharging.kt
@@ -45,14 +45,15 @@ class ForegroundAndBackgroundCharging : ContentScanner.Plan {
     }
 
     override fun getProgress(): LiveData<Pair<Int, Int>> {
-        val contentData = ScryerApplication.getScreenshotRepository().getScreenshotContent()
-        val screenshotData = ScryerApplication.getScreenshotRepository().getScreenshots()
-
-        return Transformations.switchMap(contentData) { contentList ->
-            Transformations.map(screenshotData) { screenshotList ->
-                Pair(contentList.size, screenshotList.size)
-            }
-        }
+//        val contentData = ScryerApplication.getScreenshotRepository().getScreenshotContent()
+//        val screenshotData = ScryerApplication.getScreenshotRepository().getScreenshots()
+//
+//        return Transformations.switchMap(contentData) { contentList ->
+//            Transformations.map(screenshotData) { screenshotList ->
+//                Pair(contentList.size, screenshotList.size)
+//            }
+//        }
+        return foregroundScanner.getProgress()
     }
 
     override fun isScanning(): Boolean {

--- a/app/src/main/java/org/mozilla/scryer/scan/ForegroundScanner.kt
+++ b/app/src/main/java/org/mozilla/scryer/scan/ForegroundScanner.kt
@@ -67,7 +67,11 @@ class ForegroundScanner : CoroutineScope {
 
         scanActor = actor(context = scanJob, capacity = Channel.CONFLATED) {
             for (msg in channel) {
-                FirebaseVisionTextHelper.scanAndSave()
+                FirebaseVisionTextHelper.scanAndSave { a, b ->
+                    launch (Dispatchers.Main) {
+                        progressLiveData.value = Pair(a, b)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Get scan progress directly from ForegroundScanner to temporarily fix the progress-not-update issue.
Need to check why adding an observer to searchScreenshot() makes getProgress() stop being notified.